### PR TITLE
Implement modular config loader

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# AIO-Conf
+
+`aio_conf` provides a simple but flexible way to describe an application's
+configuration and load values from multiple sources.  Values are resolved in the
+following order of priority:
+
+1. Command line arguments
+2. Environment variables
+3. Configuration files (`.json`, `.yaml` or `.ini`)
+4. Defaults defined in your spec
+
+## Developer workflow
+
+Define a configuration spec using :class:`ConfigSpec` and :class:`OptionSpec` and
+store it for distribution::
+
+```python
+from aio_conf import ConfigSpec, OptionSpec, DeveloperToolkit
+
+spec = ConfigSpec(
+    options={
+        "debug": OptionSpec(name="debug", type=bool, default=False,
+                             env_var="DEBUG", cli_arg="--debug"),
+    },
+    subconfigs={
+        "database": ConfigSpec(
+            options={
+                "host": OptionSpec("host", str, "localhost",
+                                    env_var="DB_HOST", cli_arg="--db-host"),
+                "port": OptionSpec("port", int, 3306,
+                                    env_var="DB_PORT", cli_arg="--db-port"),
+            }
+        )
+    }
+)
+
+DeveloperToolkit.spec_to_json(spec, "config_spec.json")
+```
+
+The resulting `config_spec.json` can be shipped with your application.
+
+## User workflow
+
+Load the spec and construct :class:`AIOConfig` to obtain the merged
+configuration.  The merged result can optionally be saved to an INI file for
+user editing::
+
+```python
+from aio_conf import AIOConfig, DeveloperToolkit
+
+spec = DeveloperToolkit.spec_from_json("config_spec.json")
+cfg = AIOConfig(spec)
+
+print(cfg.as_dict())
+
+cfg.save_ini("settings.ini")
+```
+
+See the tests for more examples of the supported behaviours.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
+    "PyYAML>=6.0"
 ]
 
 [tool.poetry]

--- a/src/aio_conf/__init__.py
+++ b/src/aio_conf/__init__.py
@@ -1,0 +1,268 @@
+"""Unified configuration loader for Python applications.
+
+This module provides classes to define configuration options and load them
+from multiple sources. Configuration values are resolved in the following
+order of precedence:
+
+1. Command line arguments
+2. Environment variables
+3. User supplied configuration files (JSON/YAML/INI)
+4. Default values defined in :class:`OptionSpec`
+
+The :class:`AIOConfig` class exposes the merged result via :py:meth:`as_dict`
+and can persist it to an INI file using :py:meth:`save_ini`.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict, field
+import argparse
+import configparser
+import json
+import os
+import builtins
+from pathlib import Path
+from typing import Any, Dict, Iterable, Iterator, List, Optional
+
+try:  # Optional PyYAML dependency
+    import yaml
+except Exception:  # pragma: no cover - PyYAML might not be installed
+    yaml = None
+
+
+@dataclass
+class OptionSpec:
+    """Specification of a single configuration option."""
+
+    name: str
+    type: type = str
+    default: Any = None
+    env_var: Optional[str] = None
+    cli_arg: Optional[str] = None
+    help: str = ""
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {
+            "name": self.name,
+            "type": self.type.__name__,
+            "default": self.default,
+            "env_var": self.env_var,
+            "cli_arg": self.cli_arg,
+            "help": self.help,
+        }
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "OptionSpec":
+        typ_name = data.get("type", "str")
+        typ = getattr(builtins, typ_name, str)
+        return cls(
+            name=data["name"],
+            type=typ,
+            default=data.get("default"),
+            env_var=data.get("env_var"),
+            cli_arg=data.get("cli_arg"),
+            help=data.get("help", ""),
+        )
+
+
+@dataclass
+class ConfigSpec:
+    """Collection of options and nested configuration sections."""
+
+    options: Dict[str, OptionSpec] = field(default_factory=dict)
+    subconfigs: Dict[str, "ConfigSpec"] = field(default_factory=dict)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data = {
+            "options": {k: v.to_dict() for k, v in self.options.items()},
+            "subconfigs": {k: v.to_dict() for k, v in self.subconfigs.items()},
+        }
+        return data
+
+    @classmethod
+    def from_dict(cls, data: Dict[str, Any]) -> "ConfigSpec":
+        options = {
+            name: OptionSpec.from_dict({"name": name, **spec})
+            for name, spec in data.get("options", {}).items()
+        }
+        subconfigs = {
+            name: cls.from_dict(spec)
+            for name, spec in data.get("subconfigs", {}).items()
+        }
+        return cls(options=options, subconfigs=subconfigs)
+
+
+def _iter_options(spec: ConfigSpec, path: Optional[List[str]] = None) -> Iterator[tuple[List[str], OptionSpec]]:
+    path = path or []
+    for name, opt in spec.options.items():
+        yield path + [name], opt
+    for sec_name, sub in spec.subconfigs.items():
+        yield from _iter_options(sub, path + [sec_name])
+
+
+def _set_nested(target: Dict[str, Any], path: Iterable[str], value: Any) -> None:
+    path = list(path)
+    for key in path[:-1]:
+        target = target.setdefault(key, {})
+    target[path[-1]] = value
+
+
+def _merge_dict(base: Dict[str, Any], other: Dict[str, Any]) -> None:
+    for key, value in other.items():
+        if (
+            key in base
+            and isinstance(base[key], dict)
+            and isinstance(value, dict)
+        ):
+            _merge_dict(base[key], value)
+        else:
+            base[key] = value
+
+
+class AIOConfig:
+    """Load configuration from CLI, environment variables and files."""
+
+    def __init__(
+        self,
+        spec: ConfigSpec,
+        *,
+        cli_args: Optional[List[str]] = None,
+        env: Optional[Dict[str, str]] = None,
+        config_files: Optional[List[str | os.PathLike[str]]] = None,
+    ) -> None:
+        self.spec = spec
+        self.env = env if env is not None else os.environ
+        self.cli_args = cli_args or []
+        self.config_files = [Path(p) for p in (config_files or [])]
+
+        # Start with defaults
+        self.config = self._build_defaults(spec)
+
+        # Merge file values
+        for path in self.config_files:
+            _merge_dict(self.config, self._load_file(path))
+
+        # Merge environment values
+        _merge_dict(self.config, self._load_env())
+
+        # Merge CLI values
+        _merge_dict(self.config, self._load_cli())
+
+    # ------------------------------------------------------------------ utils
+    def _build_defaults(self, spec: ConfigSpec) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for name, opt in spec.options.items():
+            result[name] = opt.default
+        for sec_name, sub in spec.subconfigs.items():
+            result[sec_name] = self._build_defaults(sub)
+        return result
+
+    def _apply_types(self, data: Dict[str, Any], spec: ConfigSpec, path: Optional[List[str]] = None) -> Dict[str, Any]:
+        path = path or []
+        typed: Dict[str, Any] = {}
+        for key, value in data.items():
+            if isinstance(value, dict) and key in spec.subconfigs:
+                typed[key] = self._apply_types(value, spec.subconfigs[key], path + [key])
+            elif key in spec.options:
+                opt = spec.options[key]
+                if isinstance(value, str) and opt.type is bool:
+                    typed[key] = value.lower() in {"1", "true", "yes", "on"}
+                else:
+                    typed[key] = opt.type(value)
+            else:
+                typed[key] = value
+        return typed
+
+    # --------------------------------------------------------------- load file
+    def _load_file(self, path: Path) -> Dict[str, Any]:
+        if not path.exists():
+            return {}
+        if path.suffix in {".json"}:
+            with path.open() as f:
+                data = json.load(f)
+            return self._apply_types(data, self.spec)
+        if path.suffix in {".yml", ".yaml"} and yaml is not None:
+            with path.open() as f:
+                data = yaml.safe_load(f) or {}
+            return self._apply_types(data, self.spec)
+        if path.suffix == ".ini":
+            cp = configparser.ConfigParser()
+            cp.read(path)
+            data: Dict[str, Any] = {
+                sec: {k: v for k, v in cp._sections.get(sec, {}).items() if k != "__name__"}
+                for sec in cp.sections()
+            }
+            if cp.defaults():
+                data.update(cp.defaults())
+            return self._apply_types(data, self.spec)
+        return {}
+
+    # ------------------------------------------------------------- load env var
+    def _load_env(self) -> Dict[str, Any]:
+        result: Dict[str, Any] = {}
+        for path, opt in _iter_options(self.spec):
+            if opt.env_var and opt.env_var in self.env:
+                raw = self.env[opt.env_var]
+                value = self._cast(raw, opt.type)
+                _set_nested(result, path, value)
+        return result
+
+    # -------------------------------------------------------------- load cli
+    def _load_cli(self) -> Dict[str, Any]:
+        parser = argparse.ArgumentParser(add_help=False)
+        for path, opt in _iter_options(self.spec):
+            if opt.cli_arg:
+                dest = "__".join(path)
+                parser.add_argument(opt.cli_arg, dest=dest, type=opt.type, help=opt.help)
+        ns, _ = parser.parse_known_args(self.cli_args)
+        result: Dict[str, Any] = {}
+        for dest, value in vars(ns).items():
+            if value is not None:
+                path = dest.split("__")
+                _set_nested(result, path, value)
+        return result
+
+    @staticmethod
+    def _cast(value: str, typ: type) -> Any:
+        if typ is bool:
+            return value.lower() in {"1", "true", "yes", "on"}
+        return typ(value)
+
+    # --------------------------------------------------------------- public API
+    def as_dict(self) -> Dict[str, Any]:
+        return self.config
+
+    def save_ini(self, path: str | os.PathLike[str]) -> None:
+        cp = configparser.ConfigParser()
+        root_options = {k: v for k, v in self.config.items() if not isinstance(v, dict)}
+        if root_options:
+            cp["DEFAULT"] = {k: str(v) for k, v in root_options.items()}
+        for section, values in self.config.items():
+            if isinstance(values, dict):
+                cp[section] = {k: str(v) for k, v in values.items()}
+        with open(path, "w") as f:
+            cp.write(f)
+
+
+# ----------------------------------------------------------------- developer toolkit
+# The developer toolkit simply exposes helpers for serialising specs to/from JSON.
+
+class DeveloperToolkit:
+    @staticmethod
+    def spec_to_json(spec: ConfigSpec, path: str | os.PathLike[str]) -> None:
+        with open(path, "w") as f:
+            json.dump(spec.to_dict(), f, indent=2)
+
+    @staticmethod
+    def spec_from_json(path: str | os.PathLike[str]) -> ConfigSpec:
+        with open(path) as f:
+            data = json.load(f)
+        return ConfigSpec.from_dict(data)
+
+
+__all__ = [
+    "OptionSpec",
+    "ConfigSpec",
+    "AIOConfig",
+    "DeveloperToolkit",
+]

--- a/src/aio_conf/developer_toolkit/__init__.py
+++ b/src/aio_conf/developer_toolkit/__init__.py
@@ -1,0 +1,3 @@
+from .. import DeveloperToolkit
+
+__all__ = ["DeveloperToolkit"]

--- a/tests/test_aio_config.py
+++ b/tests/test_aio_config.py
@@ -1,0 +1,91 @@
+import json
+import os
+import configparser
+
+import pytest
+
+from aio_conf import OptionSpec, ConfigSpec, AIOConfig
+from aio_conf.developer_toolkit import DeveloperToolkit
+
+
+def build_spec():
+    return ConfigSpec(
+        options={
+            "debug": OptionSpec(name="debug", type=bool, default=False, env_var="DEBUG", cli_arg="--debug"),
+        },
+        subconfigs={
+            "database": ConfigSpec(
+                options={
+                    "host": OptionSpec(name="host", type=str, default="localhost", env_var="DB_HOST", cli_arg="--db-host"),
+                    "port": OptionSpec(name="port", type=int, default=3306, env_var="DB_PORT", cli_arg="--db-port"),
+                }
+            )
+        }
+    )
+
+
+def test_defaults_only():
+    spec = build_spec()
+    cfg = AIOConfig(spec, cli_args=[], env={}, config_files=[])
+    data = cfg.as_dict()
+    assert data["debug"] is False
+    assert data["database"]["port"] == 3306
+
+
+def test_env_override(monkeypatch):
+    spec = build_spec()
+    monkeypatch.setenv("DB_HOST", "envhost")
+    cfg = AIOConfig(spec, cli_args=[], config_files=[])
+    assert cfg.as_dict()["database"]["host"] == "envhost"
+
+
+def test_config_file_override(tmp_path):
+    spec = build_spec()
+    config_path = tmp_path / "conf.json"
+    with open(config_path, "w") as f:
+        json.dump({"database": {"host": "filehost"}}, f)
+    cfg = AIOConfig(spec, cli_args=[], config_files=[config_path])
+    assert cfg.as_dict()["database"]["host"] == "filehost"
+
+
+def test_cli_override():
+    spec = build_spec()
+    cfg = AIOConfig(spec, cli_args=["--db-host", "clihost"], env={}, config_files=[])
+    assert cfg.as_dict()["database"]["host"] == "clihost"
+
+
+def test_merge_priority(monkeypatch, tmp_path):
+    spec = build_spec()
+    config_path = tmp_path / "conf.json"
+    with open(config_path, "w") as f:
+        json.dump({"database": {"host": "filehost"}}, f)
+    monkeypatch.setenv("DB_HOST", "envhost")
+    cfg = AIOConfig(spec, cli_args=["--db-host", "clihost"], config_files=[config_path])
+    assert cfg.as_dict()["database"]["host"] == "clihost"
+
+
+def test_ini_export(tmp_path):
+    spec = build_spec()
+    cfg = AIOConfig(spec, cli_args=["--db-port", "1234"])
+    ini_path = tmp_path / "out.ini"
+    cfg.save_ini(ini_path)
+    cp = configparser.ConfigParser()
+    cp.read(ini_path)
+    assert cp["database"]["port"] == "1234"
+
+
+def test_roundtrip(tmp_path):
+    spec = build_spec()
+    cfg = AIOConfig(spec, cli_args=["--db-port", "1234", "--db-host", "rt"])
+    ini_path = tmp_path / "out.ini"
+    cfg.save_ini(ini_path)
+    cfg2 = AIOConfig(spec, config_files=[ini_path])
+    assert cfg2.as_dict() == cfg.as_dict()
+
+
+def test_spec_json(tmp_path):
+    spec = build_spec()
+    path = tmp_path / "spec.json"
+    DeveloperToolkit.spec_to_json(spec, path)
+    spec2 = DeveloperToolkit.spec_from_json(path)
+    assert spec2.to_dict() == spec.to_dict()


### PR DESCRIPTION
## Summary
- implement `OptionSpec`, `ConfigSpec` and `AIOConfig`
- add developer toolkit helper
- provide README instructions
- add PyYAML dependency
- include unit tests

## Testing
- `PYTHONPATH=src pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68533120225c832da847146c801faeeb

## Summary by Sourcery

Implement a modular configuration loader with schema definitions, multi-source merging, and developer tooling for spec serialization

New Features:
- Introduce OptionSpec and ConfigSpec classes to define configuration schemas
- Add AIOConfig to load and merge settings from defaults, JSON/YAML/INI files, environment variables, and CLI arguments
- Provide DeveloperToolkit for serializing and deserializing ConfigSpec to/from JSON

Enhancements:
- Support nested subconfig sections and multiple file formats (JSON, YAML, INI) during configuration loading

Build:
- Add PyYAML>=6.0 as an optional dependency for YAML support

Documentation:
- Add README with usage examples for defining specs and loading configurations

Tests:
- Add comprehensive unit tests for defaults, override precedence, file and CLI overrides, INI export, roundtrip persistence, and spec JSON serialization