### PR TITLE
Refine loader parsing and enrich documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,20 +1,65 @@
 # AIO-Conf
 
-A minimal configuration system that merges configuration from CLI arguments,
-environment variables, config files and defaults. Configuration specs can be
-defined in JSON and loaded with `AIOConfig`.
+AIO-Conf is a tiny configuration system that unifies values from multiple
+sources: command-line arguments, environment variables, configuration files and
+defaults.  Specifications are declared up front so each option knows how to be
+parsed and coerced into the correct Python type.
 
-## Usage
+## Installation
+
+This project uses [Poetry](https://python-poetry.org/).  From the project
+directory install dependencies with:
+
+```bash
+poetry install
+```
+
+## Defining a specification
+
+You can declare options programmatically using `OptionSpec` and `ConfigSpec`:
+
+```python
+from aio_conf.core import ConfigSpec, OptionSpec
+
+spec = ConfigSpec([
+    OptionSpec("port", int, default=8000, env="APP_PORT", cli="--port"),
+    OptionSpec("debug", bool, default=False, env="APP_DEBUG", cli="--debug"),
+])
+```
+
+The spec can also be stored in JSON and loaded with
+`ConfigSpec.from_json_file()` or via `AIOConfig.load_from_spec()`.
+
+## Loading configuration
+
+`AIOConfig` merges all sources with the following precedence:
+
+1. CLI arguments
+2. Environment variables
+3. File values (`json` or `yaml`)
+4. Defaults defined in the spec
 
 ```python
 from aio_conf import AIOConfig
 
-cfg = AIOConfig.load_from_spec('spec.json')
-cfg.load(cli_args=['--port', '8000'], file_path='config.json')
+cfg = AIOConfig(spec)
+cfg.load(
+    cli_args=["--port", "9000"],
+    env={"APP_DEBUG": "true"},
+    file_path="config.json",
+)
 print(cfg.as_dict())
 ```
 
-Run tests with:
+Configuration can be written to an INI file:
+
+```python
+cfg.save_ini("settings.ini")
+```
+
+## Testing
+
+Run the test suite with:
 
 ```bash
 pytest -q

--- a/README.md
+++ b/README.md
@@ -50,6 +50,8 @@ cfg.load(
 )
 print(cfg.as_dict())
 ```
+The `env` parameter accepts a mapping of environment variables and defaults to
+`os.environ` when omitted.
 
 Configuration can be written to an INI file:
 

--- a/src/aio_conf/loader/__init__.py
+++ b/src/aio_conf/loader/__init__.py
@@ -2,29 +2,34 @@ from __future__ import annotations
 
 import argparse
 import json
-import os
 from pathlib import Path
 from typing import Any, Dict, List
 
 import yaml
 
-from .core import ConfigSpec
+from ..core import ConfigSpec
 
 
 def parse_cli(spec: ConfigSpec, args: List[str]) -> Dict[str, Any]:
     parser = argparse.ArgumentParser(add_help=False)
     for opt in spec.options:
         if opt.cli:
-            parser.add_argument(opt.cli, dest=opt.name, type=opt.type)
+            kwargs: Dict[str, Any] = {"dest": opt.name}
+            opt_type = opt.type
+            if opt_type is bool or (isinstance(opt_type, str) and opt_type.lower() == "bool"):
+                kwargs["action"] = "store_true"
+            else:
+                kwargs["type"] = opt.coerce
+            parser.add_argument(*opt.cli, **kwargs)
     parsed, _ = parser.parse_known_args(args)
     return {k: v for k, v in vars(parsed).items() if v is not None}
 
 
 def parse_env(spec: ConfigSpec, env: Dict[str, str]) -> Dict[str, Any]:
-    result = {}
+    result: Dict[str, Any] = {}
     for opt in spec.options:
         if opt.env and opt.env in env:
-            result[opt.name] = opt.type(env[opt.env])
+            result[opt.name] = opt.coerce(env[opt.env])
     return result
 
 

--- a/src/aio_conf/loader/__init__.py
+++ b/src/aio_conf/loader/__init__.py
@@ -20,7 +20,11 @@ def parse_cli(spec: ConfigSpec, args: List[str]) -> Dict[str, Any]:
                 kwargs["action"] = "store_true"
             else:
                 kwargs["type"] = opt.coerce
-            parser.add_argument(*opt.cli, **kwargs)
+            # ``OptionSpec`` normalizes ``cli`` to a list, but guard against
+            # any stray string values to avoid argparse treating each
+            # character as a separate flag.
+            flags = opt.cli if isinstance(opt.cli, (list, tuple)) else [opt.cli]
+            parser.add_argument(*flags, **kwargs)
     parsed, _ = parser.parse_known_args(args)
     return {k: v for k, v in vars(parsed).items() if v is not None}
 


### PR DESCRIPTION
## Summary
- fix loader imports and argument parsing
- expand environment and CLI handling
- enrich README with install and usage examples

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae1508fd8832d969be00d400d2017

## Summary by Sourcery

Refine CLI and environment loaders to use consistent coercion, boolean flags, and alias handling; enrich README with installation steps, spec definition, usage examples, and test instructions

Enhancements:
- Refine CLI parsing to auto-detect boolean flags, support multiple flag aliases, and apply OptionSpec.coerce for value conversion
- Simplify environment parsing to use OptionSpec.coerce and filter out unset options
- Remove unused imports and adjust loader import paths

Documentation:
- Add installation instructions and expand README with spec definitions, source precedence, and usage examples for CLI, environment, file loading, and INI export
- Update README testing section with refined instructions