### PR TITLE
Filter out empty CLI flags in parse_cli

### DIFF
--- a/src/aio_conf/loader/__init__.py
+++ b/src/aio_conf/loader/__init__.py
@@ -22,8 +22,12 @@ def parse_cli(spec: ConfigSpec, args: List[str]) -> Dict[str, Any]:
                 kwargs["type"] = opt.coerce
             # ``OptionSpec`` normalizes ``cli`` to a list, but guard against
             # any stray string values to avoid argparse treating each
-            # character as a separate flag.
+            # character as a separate flag. Filter out empty or ``None`` values
+            # so ``argparse`` receives only valid flags.
             flags = opt.cli if isinstance(opt.cli, (list, tuple)) else [opt.cli]
+            flags = [flag for flag in flags if flag]
+            if not flags:
+                continue
             parser.add_argument(*flags, **kwargs)
     parsed, _ = parser.parse_known_args(args)
     return {k: v for k, v in vars(parsed).items() if v is not None}

--- a/src/aio_conf/loader/__init__.py
+++ b/src/aio_conf/loader/__init__.py
@@ -25,10 +25,8 @@ def parse_cli(spec: ConfigSpec, args: List[str]) -> Dict[str, Any]:
             # character as a separate flag. Filter out empty or ``None`` values
             # so ``argparse`` receives only valid flags.
             flags = opt.cli if isinstance(opt.cli, (list, tuple)) else [opt.cli]
-            flags = [flag for flag in flags if flag]
-            if not flags:
-                continue
-            parser.add_argument(*flags, **kwargs)
+            if flags := [flag for flag in flags if flag]:
+                parser.add_argument(*flags, **kwargs)
     parsed, _ = parser.parse_known_args(args)
     return {k: v for k, v in vars(parsed).items() if v is not None}
 


### PR DESCRIPTION
## Summary
- guard against empty or `None` CLI flags when building the argument parser

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689ae6e76e90832d99f2888c64a91b68

## Summary by Sourcery

Filter out empty or None CLI flags in parse_cli to avoid parser errors

Bug Fixes:
- Filter out empty or None CLI flags before passing them to argparse
- Skip adding an argument if no valid flags remain