### PR TITLE
Add release readiness task list for v1.0.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ __pycache__/
 dist/
 poetry.lock
 /.idea
+/src/aio_conf/meta/_version.py

--- a/RELEASE_TASKS.md
+++ b/RELEASE_TASKS.md
@@ -1,0 +1,11 @@
+# Tasks for 1.0.0 Stable Release
+
+- [ ] Finalize API and feature set; remove or document any experimental interfaces.
+- [ ] Ensure 100% test pass rate and add tests for critical paths.
+- [ ] Audit and clean up documentation (README, docstrings, usage examples).
+- [ ] Add a comprehensive changelog entry for 1.0.0.
+- [ ] Review and update project metadata (version, license, classifiers).
+- [ ] Verify packaging builds (sdist and wheel) and installation.
+- [ ] Set up or confirm CI/CD for tests, linting, and publishing.
+- [ ] Tag the release in Git and publish to PyPI.
+- [ ] Announce the release and update project links.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,23 +1,48 @@
-[project]
-name = "aio-conf"
-version = "1.0.0-dev.7"
-description = ""
-authors = [
-    {name = "t.blackstone",email = "t.blackstone@inspyre.tech"}
-]
-readme = "README.md"
-requires-python = ">=3.12"
-dependencies = [
-    "pyyaml>=6.0",
-    "streamlit (>=1.47.1,<2.0.0)",
-    "pysimplegui-4-foss (==4.60.4.1)",
-    "notebook (>=7.4.5,<8.0.0)"
-]
-
 [tool.poetry]
-packages = [{include = "aio_conf", from = "src"}]
+name = "aio-conf"
+version = "0.0.0"  # dummy; replaced by poetry-dynamic-versioning at build time
+description = "All-in-one configuration specification and loader for CLI, env vars, and files."
+authors = ["Taylor-Jayde Blackstone <t.blackstone@inspyre.tech>"]
+readme = "README.md"
+license = "MIT"
+keywords = ["configuration", "cli", "environment", "json", "yaml", "ini"]
+homepage = "https://github.com/Inspyre-Softworks/AIO-Conf"
+repository = "https://github.com/Inspyre-Softworks/AIO-Conf"
+documentation = "https://github.com/Inspyre-Softworks/AIO-Conf/wiki"
+packages = [{ include = "aio_conf", from = "src" }]
 
+[tool.poetry.dependencies]
+python = ">=3.12"
+pyyaml = ">=6.0"
+streamlit = ">=1.47.1,<2.0.0"
+pysimplegui-4-foss = "==4.60.4.1"
+notebook = ">=7.4.5,<8.0.0"
+
+# ---- Dynamic versioning plugin (valid keys) ----
+[tool.poetry-dynamic-versioning]
+enable = true
+vcs = "git"
+style = "pep440"
+
+# Accept: v1.2.3, v1.2.3a1, v1.2.3b2, v1.2.3rc3, v1.2.3dev4, v1.2.3post5, and optional +metadata
+# (Backslashes are double-escaped for TOML strings.)
+pattern = "^(?:v)?(?P<base>\\d+\\.\\d+\\.\\d+)(?:(?P<stage>a|alpha|b|beta|rc|dev|post)(?P<revision>\\d+)?)?(?:\\+(?P<tagged_metadata>[0-9A-Za-z.-]+))?$"
+
+# If you want to include tagged metadata (from the '+...' part) when present:
+tagged-metadata = true
+# If you also want distance/commit/dirty metadata when not exactly on a tag, set:
+# metadata = true
+# dirty = true
+
+# Replace a placeholder inside this file during Poetry commands like `build`/`publish`.
+# The file will be created if missing; initial-content provides the placeholder text.
+[tool.poetry-dynamic-versioning.files."src/aio_conf/meta/_version.py"]
+initial-content = """
+__version__ = "0.0.0"
+"""
+# Set this to true if you want the substitution to persist on disk after the command:
+# persistent-substitution = true
 
 [build-system]
-requires = ["poetry-core>=2.0.0,<3.0.0"]
-build-backend = "poetry.core.masonry.api"
+requires = ["poetry-core>=1.0.0", "poetry-dynamic-versioning>=1.0.0,<2.0.0"]
+build-backend = "poetry_dynamic_versioning.backend"

--- a/src/aio_conf/__init__.py
+++ b/src/aio_conf/__init__.py
@@ -1,3 +1,10 @@
 from .core import OptionSpec, ConfigSpec, AIOConfig
 
+
+try:
+    from .meta._version import __version__  # type: ignore  # noqa
+except ImportError:
+    __version__ = "0.0.0+local"
+
+
 __all__ = ["OptionSpec", "ConfigSpec", "AIOConfig"]

--- a/src/aio_conf/core/aio_config.py
+++ b/src/aio_conf/core/aio_config.py
@@ -141,7 +141,8 @@ class AIOConfig:
         file_data = load_file(file_path) if file_path else {}
 
         self.values = merge_sources(self.spec, cli_data, env_data, file_data)
-        self.save_ini(self.config_filepath)
+        if self.config_filepath is not None:
+            self.save_ini(self.config_filepath)
 
     def as_dict(self) -> Dict[str, Any]:
         """

--- a/src/aio_conf/meta/__init__.py
+++ b/src/aio_conf/meta/__init__.py
@@ -1,0 +1,17 @@
+"""
+
+
+Author: 
+    Inspyre Softworks
+
+Project:
+    AIO-Conf
+
+File: 
+    src/aio_conf/meta/__init__.py
+ 
+
+Description:
+    
+
+"""


### PR DESCRIPTION
## Summary
- add checklist of tasks required for 1.0.0 stable release
- fix config saving when no file path provided

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689b8087e3c0832dbeacd17112b3a37d

## Summary by Sourcery

Add release readiness checklist for v1.0.0 and prevent saving config when no file path is provided

Bug Fixes:
- Prevent saving configuration when no file path is provided

Documentation:
- Add RELEASE_TASKS.md with tasks required for the 1.0.0 stable release