### PR TITLE
Add CLI tooling, loader registry, and richer env parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,8 +35,8 @@ The spec can also be stored in JSON and loaded with
 `AIOConfig` merges all sources with the following precedence:
 
 1. CLI arguments
-2. Environment variables
-3. File values (`json` or `yaml`)
+2. Environment variables (including nested values like `APP_DB__HOST`)
+3. File values (`json`, `yaml`, `toml` or `ini`/`cfg`)
 4. Defaults defined in the spec
 
 ```python
@@ -58,6 +58,19 @@ Configuration can be written to an INI file:
 ```python
 cfg.save_ini("settings.ini")
 ```
+
+## Command line helper
+
+Install the project (or use `poetry run`) to access the `aio-conf` CLI:
+
+```bash
+aio-conf init spec.json          # create a starter spec template
+aio-conf validate spec.json      # sanity check the spec
+aio-conf sample spec.json --format toml --output sample.toml
+```
+
+All commands provide blunt-but-helpful feedback, and `sample` understands the
+same output formats that the loader accepts.
 
 ## Testing
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -14,6 +14,9 @@ dependencies = [
     "notebook (>=7.4.5,<8.0.0)"
 ]
 
+[project.scripts]
+"aio-conf" = "aio_conf.cli:main"
+
 [tool.poetry]
 packages = [{include = "aio_conf", from = "src"}]
 

--- a/src/aio_conf/cli.py
+++ b/src/aio_conf/cli.py
@@ -1,0 +1,186 @@
+from __future__ import annotations
+
+import argparse
+import json
+from pathlib import Path
+from typing import Any, Dict, Iterable
+
+import yaml
+
+from .core import ConfigSpec
+from .writer import to_ini
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="aio-conf",
+        description="Swiss army knife for AIO-Conf specifications.",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    init_cmd = sub.add_parser(
+        "init",
+        help="Generate a starter configuration spec",
+    )
+    init_cmd.add_argument("path", type=Path, help="Where to write the new spec file")
+    init_cmd.add_argument(
+        "--force",
+        action="store_true",
+        help="Overwrite the file if it already exists",
+    )
+
+    validate_cmd = sub.add_parser(
+        "validate",
+        help="Validate a configuration spec",
+    )
+    validate_cmd.add_argument("spec", type=Path, help="Path to the JSON spec file")
+
+    sample_cmd = sub.add_parser(
+        "sample",
+        help="Generate a sample configuration file from the spec",
+    )
+    sample_cmd.add_argument("spec", type=Path, help="Path to the JSON spec file")
+    sample_cmd.add_argument(
+        "--format",
+        default="yaml",
+        choices=["yaml", "json", "toml", "ini"],
+        help="Output format for the sample file",
+    )
+    sample_cmd.add_argument(
+        "--output",
+        type=Path,
+        help="Optional file path. Defaults to stdout if omitted.",
+    )
+
+    return parser
+
+
+def main(argv: Iterable[str] | None = None) -> int:
+    parser = build_parser()
+    args = parser.parse_args(list(argv) if argv is not None else None)
+
+    if args.command == "init":
+        return _cmd_init(args.path, force=args.force)
+    if args.command == "validate":
+        return _cmd_validate(args.spec)
+    if args.command == "sample":
+        return _cmd_sample(args.spec, fmt=args.format, output=args.output)
+    parser.error("Congratulations, you found an impossible branch.")
+    return 2
+
+
+def _cmd_init(path: Path, *, force: bool) -> int:
+    template = {
+        "options": [
+            {
+                "name": "app_name",
+                "type": "str",
+                "default": "my-app",
+                "description": "Human readable application name.",
+                "env": "APP_NAME",
+                "cli": ["--app-name"],
+            },
+            {
+                "name": "debug",
+                "type": "bool",
+                "default": False,
+                "description": "Enable developer friendly behaviour.",
+                "env": "APP_DEBUG",
+                "cli": ["--debug"],
+            },
+        ]
+    }
+    if path.exists() and not force:
+        print(f"Nope. {path} already exists. Pass --force if you really mean it.")
+        return 1
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(template, indent=2), encoding="utf-8")
+    print(f"Created starter spec at {path}")
+    return 0
+
+
+def _cmd_validate(path: Path) -> int:
+    try:
+        ConfigSpec.from_json_file(path)
+    except Exception as exc:  # pragma: no cover - exercised via tests
+        print(f"Spec check failed spectacularly: {exc}")
+        return 1
+    print("Spec looks good. Gold star achieved!")
+    return 0
+
+
+def _cmd_sample(path: Path, *, fmt: str, output: Path | None) -> int:
+    try:
+        spec = ConfigSpec.from_json_file(path)
+    except Exception as exc:
+        print(f"Couldn't read that spec: {exc}")
+        return 1
+
+    sample = _defaults_from_spec(spec)
+    try:
+        text = _render_sample(sample, fmt)
+    except ValueError as exc:
+        print(str(exc))
+        return 1
+
+    if output:
+        output.parent.mkdir(parents=True, exist_ok=True)
+        output.write_text(text, encoding="utf-8")
+        print(f"Sample configuration written to {output}")
+    else:
+        print(text)
+    return 0
+
+
+def _defaults_from_spec(spec: ConfigSpec) -> Dict[str, Any]:
+    defaults: Dict[str, Any] = {}
+    for opt in spec.options:
+        defaults[opt.name] = opt.default if opt.default is not None else f"<{opt.type}>"
+    return defaults
+
+
+def _render_sample(data: Dict[str, Any], fmt: str) -> str:
+    fmt = fmt.lower()
+    if fmt == "yaml":
+        return yaml.safe_dump(data, sort_keys=False)
+    if fmt == "json":
+        return json.dumps(data, indent=2)
+    if fmt == "ini":
+        return to_ini(data)
+    if fmt == "toml":
+        return _to_toml(data)
+    raise ValueError(f"Unknown format '{fmt}'")
+
+
+def _to_toml(data: Dict[str, Any]) -> str:
+    lines: list[str] = []
+    for key, value in data.items():
+        if isinstance(value, dict):
+            lines.append(f"[{key}]")
+            for inner_key, inner_value in value.items():
+                lines.append(f"{inner_key} = {_toml_repr(inner_value)}")
+        else:
+            lines.append(f"{key} = {_toml_repr(value)}")
+    return "\n".join(lines) + "\n"
+
+
+def _toml_repr(value: Any) -> str:
+    if isinstance(value, str):
+        return json.dumps(value)
+    if isinstance(value, bool):
+        return "true" if value else "false"
+    if isinstance(value, (int, float)):
+        return str(value)
+    if isinstance(value, dict):
+        inner = ", ".join(f"{k} = {_toml_repr(v)}" for k, v in value.items())
+        return f"{{{inner}}}"
+    if isinstance(value, (list, tuple, set)):
+        inner = ", ".join(_toml_repr(v) for v in value)
+        return f"[{inner}]"
+    if value is None:
+        return "null"
+    return json.dumps(str(value))
+
+
+if __name__ == "__main__":  # pragma: no cover
+    raise SystemExit(main())

--- a/src/aio_conf/core/aio_config.py
+++ b/src/aio_conf/core/aio_config.py
@@ -141,7 +141,8 @@ class AIOConfig:
         file_data = load_file(file_path) if file_path else {}
 
         self.values = merge_sources(self.spec, cli_data, env_data, file_data)
-        self.save_ini(self.config_filepath)
+        if self.config_filepath is not None:
+            self.save_ini(self.config_filepath)
 
     def as_dict(self) -> Dict[str, Any]:
         """

--- a/src/aio_conf/core/opt_spec.py
+++ b/src/aio_conf/core/opt_spec.py
@@ -4,6 +4,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Callable, Iterable, Optional, Union
 
+import json
+
 
 @dataclass(slots=True)
 class OptionSpec:
@@ -150,6 +152,10 @@ class OptionSpec:
             return _coerce_bool
         if self.type is Path:
             return _coerce_path
+        if self.type is list or self.type is tuple:
+            return _coerce_list
+        if self.type is dict:
+            return _coerce_dict
         return self.type  # int, float, str, etc.
 
     @staticmethod
@@ -161,6 +167,8 @@ class OptionSpec:
             'bool': _coerce_bool,
             'path': _coerce_path,
             'Path': _coerce_path,
+            'list': _coerce_list,
+            'dict': _coerce_dict,
         }
         try:
             return table[name]
@@ -195,6 +203,102 @@ def _coerce_path(value: Any) -> Path:
     if isinstance(value, Path):
         return value
     return Path(str(value))
+
+
+def _coerce_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    if isinstance(value, tuple):
+        return list(value)
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return []
+        lowered = text.lower()
+        if lowered in {"none", "null"}:
+            return []
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = [_infer_scalar(chunk) for chunk in text.split(',') if chunk.strip()]
+        else:
+            if isinstance(parsed, list):
+                return parsed
+            if isinstance(parsed, (tuple, set)):
+                return list(parsed)
+            # Fallback for scalars encoded as JSON
+            return [_infer_scalar(parsed)]
+        return parsed
+    if isinstance(value, Iterable) and not isinstance(value, (bytes, bytearray, dict)):
+        return list(value)
+    return [_infer_scalar(value)]
+
+
+def _coerce_dict(value: Any) -> dict[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, dict):
+        return {str(k): _infer_scalar(v) for k, v in value.items()}
+    if isinstance(value, str):
+        text = value.strip()
+        if not text:
+            return {}
+        lowered = text.lower()
+        if lowered in {"none", "null"}:
+            return {}
+        try:
+            parsed = json.loads(text)
+        except json.JSONDecodeError:
+            parsed = None
+        else:
+            if isinstance(parsed, dict):
+                return {str(k): _infer_scalar(v) for k, v in parsed.items()}
+        items: dict[str, Any] = {}
+        for chunk in text.split(','):
+            if not chunk.strip():
+                continue
+            if '=' not in chunk:
+                raise ValueError(
+                    "Dictionary strings must be JSON or comma-separated key=value pairs"
+                )
+            key, raw_value = chunk.split('=', 1)
+            items[key.strip()] = _infer_scalar(raw_value.strip())
+        return items
+    if isinstance(value, Iterable) and not isinstance(value, (str, bytes, bytearray)):
+        raise ValueError('Cannot coerce non-string iterable to dict; use key=value pairs')
+    raise ValueError(f'Unsupported value for dict coercion: {value!r}')
+
+
+def _infer_scalar(value: Any) -> Any:
+    if isinstance(value, (dict, list, tuple)):
+        return value
+    if isinstance(value, bool):
+        return value
+    if isinstance(value, (int, float)):
+        return value
+    if isinstance(value, str):
+        text = value.strip()
+        if text == "":
+            return ""
+        lowered = text.lower()
+        if lowered in {"true", "false"}:
+            return lowered == "true"
+        if lowered in {"null", "none"}:
+            return None
+        try:
+            return json.loads(text)
+        except json.JSONDecodeError:
+            pass
+        try:
+            return int(text)
+        except ValueError:
+            try:
+                return float(text)
+            except ValueError:
+                return text
+    return value
 
 
 __all__ = ['OptionSpec']

--- a/src/aio_conf/loader/__init__.py
+++ b/src/aio_conf/loader/__init__.py
@@ -1,55 +1,213 @@
 from __future__ import annotations
 
-import argparse
-import json
+from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any, Dict, Iterable, MutableMapping
+
+import json
+from configparser import ConfigParser
 
 import yaml
 
+try:  # Python 3.11+
+    import tomllib
+except ModuleNotFoundError:  # pragma: no cover - fallback for older Python
+    tomllib = None  # type: ignore[assignment]
+
 from ..core import ConfigSpec
+from ..core.opt_spec import OptionSpec, _infer_scalar
 
 
-def parse_cli(spec: ConfigSpec, args: List[str]) -> Dict[str, Any]:
+class UnknownFileFormatError(RuntimeError):
+    """Raised when no loader is registered for a file extension."""
+
+
+@dataclass(slots=True)
+class FileLoader:
+    """Simple file-loader wrapper used by :class:`LoaderRegistry`."""
+
+    suffixes: tuple[str, ...]
+
+    def load(self, path: Path) -> dict[str, Any]:  # pragma: no cover - interface stub
+        raise NotImplementedError
+
+
+class LoaderRegistry:
+    """Registry for mapping file extensions to loader implementations."""
+
+    def __init__(self) -> None:
+        self._loaders: dict[str, FileLoader] = {}
+
+    def register(self, loader: FileLoader) -> None:
+        for suffix in loader.suffixes:
+            normalized = suffix.lower()
+            self._loaders[normalized] = loader
+
+    def load(self, path: Path) -> dict[str, Any]:
+        suffix = path.suffix.lower()
+        loader = self._loaders.get(suffix)
+        if loader is None:
+            raise UnknownFileFormatError(f"No loader registered for '{suffix}'")
+        return loader.load(path)
+
+
+class JsonLoader(FileLoader):
+    suffixes = (".json",)
+
+    def load(self, path: Path) -> dict[str, Any]:
+        text = path.read_text(encoding="utf-8")
+        return json.loads(text or "{}")
+
+
+class YamlLoader(FileLoader):
+    suffixes = (".yaml", ".yml")
+
+    def load(self, path: Path) -> dict[str, Any]:
+        text = path.read_text(encoding="utf-8")
+        data = yaml.safe_load(text)
+        return data or {}
+
+
+class TomlLoader(FileLoader):
+    suffixes = (".toml",)
+
+    def load(self, path: Path) -> dict[str, Any]:
+        if tomllib is None:
+            raise RuntimeError("tomllib is unavailable; cannot parse TOML files")
+        with path.open("rb") as fp:
+            data = tomllib.load(fp)
+        return data or {}
+
+
+class IniLoader(FileLoader):
+    suffixes = (".ini", ".cfg")
+
+    def load(self, path: Path) -> dict[str, Any]:
+        parser = ConfigParser()
+        parser.read(path, encoding="utf-8")
+        return _configparser_to_dict(parser)
+
+
+def _configparser_to_dict(parser: ConfigParser) -> dict[str, Any]:
+    data: dict[str, Any] = {}
+    defaults = {k: _infer_scalar(v) for k, v in parser.defaults().items()}
+    data.update(defaults)
+    for section in parser.sections():
+        items = {k: _infer_scalar(v) for k, v in parser[section].items()}
+        if section.lower() == "default":
+            data.update(items)
+        else:
+            data[section] = items
+    return data
+
+
+_registry = LoaderRegistry()
+_registry.register(JsonLoader(JsonLoader.suffixes))
+_registry.register(YamlLoader(YamlLoader.suffixes))
+if tomllib is not None:
+    _registry.register(TomlLoader(TomlLoader.suffixes))
+_registry.register(IniLoader(IniLoader.suffixes))
+
+
+def get_registry() -> LoaderRegistry:
+    """Return the global loader registry."""
+
+    return _registry
+
+
+def register_loader(loader: FileLoader) -> None:
+    """Register a custom file loader globally."""
+
+    _registry.register(loader)
+
+
+def parse_cli(spec: ConfigSpec, args: Iterable[str]) -> Dict[str, Any]:
+    import argparse
+
     parser = argparse.ArgumentParser(add_help=False)
     for opt in spec.options:
         if opt.cli:
             kwargs: Dict[str, Any] = {"dest": opt.name}
             opt_type = opt.type
-            if opt_type is bool or (isinstance(opt_type, str) and opt_type.lower() == "bool"):
+            if opt_type is bool or (isinstance(opt_type, str) and str(opt_type).lower() == "bool"):
                 kwargs["action"] = "store_true"
             else:
                 kwargs["type"] = opt.coerce
-            # ``OptionSpec`` normalizes ``cli`` to a list, but guard against
-            # any stray string values to avoid argparse treating each
-            # character as a separate flag. Filter out empty or ``None`` values
-            # so ``argparse`` receives only valid flags.
             flags = opt.cli if isinstance(opt.cli, (list, tuple)) else [opt.cli]
-            if flags := [flag for flag in flags if flag]:
-                parser.add_argument(*flags, **kwargs)
-    parsed, _ = parser.parse_known_args(args)
+            if flags:
+                parser.add_argument(*[flag for flag in flags if flag], **kwargs)
+    parsed, _ = parser.parse_known_args(list(args))
     return {k: v for k, v in vars(parsed).items() if v is not None}
 
 
-def parse_env(spec: ConfigSpec, env: Dict[str, str]) -> Dict[str, Any]:
-    result: Dict[str, Any] = {}
+def parse_env(spec: ConfigSpec, env: MutableMapping[str, str]) -> Dict[str, Any]:
+    resolved: Dict[str, Any] = {}
     for opt in spec.options:
-        if opt.env and opt.env in env:
-            result[opt.name] = opt.coerce(env[opt.env])
-    return result
+        if not opt.env:
+            continue
+        base_key = opt.env
+        nested_prefix = f"{base_key}__"
+        direct_value = env.get(base_key)
+        nested_pairs = {k: v for k, v in env.items() if k.startswith(nested_prefix)}
+        if direct_value is not None:
+            try:
+                resolved[opt.name] = opt.coerce(direct_value)
+            except ValueError as exc:
+                raise ValueError(f"Environment variable '{base_key}' is invalid: {exc}") from exc
+            continue
+        if nested_pairs:
+            nested_dict = _build_nested_dict(nested_pairs, nested_prefix)
+            if _expects_mapping(opt):
+                resolved[opt.name] = opt.coerce(nested_dict)
+            else:
+                resolved[opt.name] = nested_dict
+    return resolved
 
 
-def load_file(path: str | Path) -> Dict[str, Any]:
+def _expects_mapping(opt: OptionSpec) -> bool:
+    expected = opt.type
+    if isinstance(expected, str):
+        return expected.lower() == "dict"
+    return expected is dict
+
+
+def _build_nested_dict(pairs: Dict[str, str], prefix: str) -> Dict[str, Any]:
+    root: Dict[str, Any] = {}
+    for env_key, raw_value in pairs.items():
+        path = env_key[len(prefix) :]
+        segments = [segment for segment in path.split("__") if segment]
+        if not segments:
+            continue
+        cursor: Dict[str, Any] = root
+        for segment in segments[:-1]:
+            cursor = cursor.setdefault(_normalize_env_key(segment), {})  # type: ignore[assignment]
+        cursor[_normalize_env_key(segments[-1])] = _infer_scalar(raw_value)
+    return root
+
+
+def _normalize_env_key(segment: str) -> str:
+    return segment.strip().lower().replace("-", "_")
+
+
+def load_file(path: str | Path | None) -> Dict[str, Any]:
     if not path:
         return {}
-    path = Path(path)
-    if not path.exists():
+    p = Path(path)
+    if not p.exists() or not p.is_file():
         return {}
-    text = path.read_text()
-    if path.suffix in {".yaml", ".yml"}:
-        data = yaml.safe_load(text) or {}
-    elif path.suffix == ".json":
-        data = json.loads(text)
-    else:
-        data = {}
-    return data
+    try:
+        return _registry.load(p)
+    except UnknownFileFormatError:
+        return {}
+
+
+__all__ = [
+    "FileLoader",
+    "LoaderRegistry",
+    "UnknownFileFormatError",
+    "get_registry",
+    "register_loader",
+    "parse_cli",
+    "parse_env",
+    "load_file",
+]

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,41 @@
+from pathlib import Path
+
+from aio_conf.cli import main as cli_main
+from aio_conf.core import ConfigSpec, OptionSpec
+
+
+def write_spec(path: Path) -> None:
+    spec = ConfigSpec(
+        [
+            OptionSpec("app_name", "str", default="demo", env="APP_NAME"),
+            OptionSpec("debug", "bool", default=False, env="APP_DEBUG"),
+        ]
+    )
+    path.write_text(spec.to_json(), encoding="utf-8")
+
+
+def test_cli_validate_and_sample(tmp_path, capsys):
+    spec_path = tmp_path / "spec.json"
+    write_spec(spec_path)
+
+    exit_code = cli_main(["validate", str(spec_path)])
+    captured = capsys.readouterr()
+    assert exit_code == 0
+    assert "Gold star" in captured.out
+
+    sample_path = tmp_path / "sample.toml"
+    exit_code = cli_main(["sample", str(spec_path), "--output", str(sample_path), "--format", "toml"])
+    assert exit_code == 0
+    assert "sample" in capsys.readouterr().out.lower()
+    assert sample_path.exists()
+    text = sample_path.read_text()
+    assert "app_name" in text
+
+
+def test_cli_init(tmp_path, capsys):
+    target = tmp_path / "new-spec.json"
+    exit_code = cli_main(["init", str(target)])
+    assert exit_code == 0
+    assert target.exists()
+    out = capsys.readouterr().out
+    assert "starter spec" in out

--- a/tests/test_loading.py
+++ b/tests/test_loading.py
@@ -1,5 +1,8 @@
+import json
+
 from aio_conf import AIOConfig
 from aio_conf.core import ConfigSpec, OptionSpec
+from aio_conf.loader import load_file, parse_env
 
 
 def make_spec():
@@ -32,3 +35,38 @@ def test_to_ini(tmp_path):
     cfg.save_ini(ini_path)
     text = ini_path.read_text()
     assert "port = 8000" in text
+
+
+def test_load_multiple_formats(tmp_path):
+    data = {"port": 9001, "debug": True}
+    json_path = tmp_path / "config.json"
+    yaml_path = tmp_path / "config.yaml"
+    toml_path = tmp_path / "config.toml"
+    ini_path = tmp_path / "config.ini"
+
+    json_path.write_text(json.dumps(data), encoding="utf-8")
+    yaml_path.write_text("port: 9001\ndebug: true\n", encoding="utf-8")
+    toml_path.write_text("port = 9001\ndebug = true\n", encoding="utf-8")
+    ini_path.write_text("[DEFAULT]\nport = 9001\ndebug = true\n", encoding="utf-8")
+
+    for path in [json_path, yaml_path, toml_path, ini_path]:
+        loaded = load_file(path)
+        assert loaded["port"] == 9001
+        assert loaded["debug"] is True
+
+
+def test_parse_env_with_nested_structure():
+    spec = ConfigSpec(
+        [
+            OptionSpec("database", "dict", default={}, env="APP_DB"),
+            OptionSpec("features", "list", default=[], env="APP_FEATURES"),
+        ]
+    )
+    env = {
+        "APP_DB__HOST": "localhost",
+        "APP_DB__PORT": "5432",
+        "APP_FEATURES": "alpha,beta,gamma",
+    }
+    parsed = parse_env(spec, env)
+    assert parsed["database"] == {"host": "localhost", "port": 5432}
+    assert parsed["features"] == ["alpha", "beta", "gamma"]

--- a/tests/test_option_spec.py
+++ b/tests/test_option_spec.py
@@ -1,0 +1,28 @@
+import pytest
+
+from aio_conf.core import OptionSpec
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ("a,b,c", ["a", "b", "c"]),
+        ("[1, 2, 3]", [1, 2, 3]),
+        ([], []),
+    ],
+)
+def test_list_coercion(value, expected):
+    opt = OptionSpec("items", "list")
+    assert opt.coerce(value) == expected
+
+
+@pytest.mark.parametrize(
+    "value,expected",
+    [
+        ('{"host": "localhost", "port": 5432}', {"host": "localhost", "port": 5432}),
+        ("host=localhost,port=5432", {"host": "localhost", "port": 5432}),
+    ],
+)
+def test_dict_coercion(value, expected):
+    opt = OptionSpec("database", "dict")
+    assert opt.coerce(value) == expected


### PR DESCRIPTION
## Summary
- add a modular file loader registry with built-in JSON/YAML/TOML/INI support
- extend environment variable handling and option coercion for nested, list, and dict values
- provide an `aio-conf` CLI for spec init/validation/sample generation and document the workflow

## Testing
- pytest -q

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690eae7bcb80832db8fd36508765fce5)

## Summary by Sourcery

Introduce a pluggable configuration loader registry, richer option coercion and environment parsing, and a user-facing CLI for working with configuration specs.

New Features:
- Add a file loader registry with built-in support for JSON, YAML, TOML, and INI/CFG configuration files.
- Introduce an `aio-conf` command-line tool to initialize, validate, and generate sample configuration specs and files.
- Extend option coercion to handle list and dict types from strings, JSON, and iterables.
- Support nested environment variable-based configuration using double-underscore notation for structured values.

Enhancements:
- Make configuration file loading more robust by ignoring unknown extensions and non-existent or non-file paths.
- Prevent automatic INI saving unless a configuration filepath is explicitly configured.

Build:
- Register the `aio-conf` console script entry point in the project configuration.

Documentation:
- Update README to document the expanded file format support, nested environment variables, and the new `aio-conf` CLI workflow.

Tests:
- Add tests covering multi-format file loading, nested environment parsing, list and dict coercion, and the new CLI commands.